### PR TITLE
Using attachments and colors + more seperation of variables

### DIFF
--- a/teamcity-slack-integration-server/src/main/java/com/enlivenhq/slack/SlackWrapper.java
+++ b/teamcity-slack-integration-server/src/main/java/com/enlivenhq/slack/SlackWrapper.java
@@ -14,13 +14,9 @@ public class SlackWrapper
 
     protected String channel;
 
-    public String send(String message)
+    public String send(String project, String build, String statusText, String statusColor)
     {
-        String formattedPayload =
-                "payload={ \"text\": \"" + message +
-                "\", \"channel\": \"" + this.getChannel() +
-                "\", \"username\": \"" + this.getUsername() + "\" }";
-
+        String formattedPayload = "payload={text: \"" + project + " #" + build + " " + statusText + "\",attachments: [{fallback: \"" + project + " #" + build + " " + statusText + "\",text: \"" + project + " #" + build + " " + statusText + "\",pretext: \"Build Status\",color: \"" + statusColor + "\",fields: [{title: \"Project\",value: \"" + project + "\",short: false},{title: \"Build\",value: \"" + build + "\",short: true},{title: \"Status\",value: \"" + statusText + "\",short: false}]}],channel: \"" + this.getChannel() + "\",username: \"" + this.getUsername() + "\"}";
 
         try {
             URL url = new URL(this.getSlackUrl());

--- a/teamcity-slack-integration-server/src/main/java/com/enlivenhq/teamcity/SlackNotificator.java
+++ b/teamcity-slack-integration-server/src/main/java/com/enlivenhq/teamcity/SlackNotificator.java
@@ -51,38 +51,31 @@ public class SlackNotificator implements Notificator {
     }
 
     public void notifyBuildFailed(@NotNull SRunningBuild sRunningBuild, @NotNull Set<SUser> users) {
-         sendNotification("@channel: Build " + sRunningBuild.getFullName() + " #" +
-                sRunningBuild.getBuildNumber() + " failed.", users);
+         sendNotification(sRunningBuild.getFullName(), sRunningBuild.getBuildNumber(), "failed", "danger", users);
     }
 
     public void notifyBuildFailedToStart(@NotNull SRunningBuild sRunningBuild, @NotNull Set<SUser> users) {
-        sendNotification("@channel: Build " + sRunningBuild.getFullName() + " #" +
-                sRunningBuild.getBuildNumber() + " failed to start.", users);
+        sendNotification(sRunningBuild.getFullName(), sRunningBuild.getBuildNumber(), "failed to start", "danger", users);
     }
 
     public void notifyBuildSuccessful(@NotNull SRunningBuild sRunningBuild, @NotNull Set<SUser> users) {
-        sendNotification("@channel: Build " + sRunningBuild.getFullName() + " #" +
-                sRunningBuild.getBuildNumber() + " built successfully.", users);
+        sendNotification(sRunningBuild.getFullName(), sRunningBuild.getBuildNumber(), "built successfully", "good", users);
     }
 
     public void notifyLabelingFailed(@NotNull Build build, @NotNull VcsRoot vcsRoot, @NotNull Throwable throwable, @NotNull Set<SUser> sUsers) {
-        sendNotification("@channel: Build " + build.getFullName() + " #" +
-                build.getBuildNumber() + " labeling failed.", sUsers);
+        sendNotification(build.getFullName(), build.getBuildNumber(), "labeling failed", "danger", sUsers);
     }
 
     public void notifyBuildFailing(@NotNull SRunningBuild sRunningBuild, @NotNull Set<SUser> sUsers) {
-        sendNotification("@channel: Build " + sRunningBuild.getFullName() + " #" +
-                sRunningBuild.getBuildNumber() + " failing.", sUsers);
+        sendNotification(sRunningBuild.getFullName(), sRunningBuild.getBuildNumber(), "failing", "danger", sUsers);
     }
 
     public void notifyBuildProbablyHanging(@NotNull SRunningBuild sRunningBuild, @NotNull Set<SUser> sUsers) {
-        sendNotification("@channel: Build " + sRunningBuild.getFullName() + " #" +
-                sRunningBuild.getBuildNumber() + " probably hanging.", sUsers);
+        sendNotification(sRunningBuild.getFullName(), sRunningBuild.getBuildNumber(), "probably hanging", "warning", sUsers);
     }
 
     public void notifyBuildStarted(@NotNull SRunningBuild sRunningBuild, @NotNull Set<SUser> sUsers) {
-        sendNotification("@channel: Build " + sRunningBuild.getFullName() + " #" +
-                sRunningBuild.getBuildNumber() + " started.", sUsers);
+        sendNotification(sRunningBuild.getFullName(), sRunningBuild.getBuildNumber(), "started", "warning", sUsers);
     }
 
     public void notifyResponsibleChanged(@NotNull SBuildType sBuildType, @NotNull Set<SUser> sUsers) {
@@ -148,10 +141,10 @@ public class SlackNotificator implements Notificator {
         return userPropertyInfos;
     }
 
-    private void sendNotification(String message, Set<SUser> users) {
+    private void sendNotification(String project, String build, String statusText, String statusColor, Set<SUser> users) {
         for (SUser user : users) {
             SlackWrapper slackWrapper = getSlackWrapperWithUser(user);
-            slackWrapper.send(message);
+            slackWrapper.send(project, build, statusText, statusColor);
         }
     }
 


### PR DESCRIPTION
Using Slack [attachments](https://api.slack.com/docs/attachments) and colors for each build type (start=yellow, fail=red, success=green, hang=yellow, etc.). Also seperated variables for project name and build number.

fixes #3 