### PR TITLE
Add to notification link to a build and status text (latter in case of failure only) + minor fixes

### DIFF
--- a/teamcity-slack-integration-server/src/main/java/com/enlivenhq/slack/SlackWrapper.java
+++ b/teamcity-slack-integration-server/src/main/java/com/enlivenhq/slack/SlackWrapper.java
@@ -1,5 +1,6 @@
 package com.enlivenhq.slack;
 
+import jetbrains.buildServer.Build;
 import jetbrains.buildServer.web.util.WebUtil;
 
 import javax.net.ssl.HttpsURLConnection;
@@ -14,17 +15,20 @@ public class SlackWrapper
 
     protected String channel;
 
-    public String send(String project, String build, String statusText, String statusColor) throws IOException
+    protected String serverUrl;
+
+    public String send(String project, String build, String statusText, String statusColor, Build bt) throws IOException
     {
-        project = WebUtil.encode(project);
-        build = WebUtil.encode(build);
-        statusText = WebUtil.encode(statusText);
+        String btId = bt.getBuildTypeExternalId();
+        project = WebUtil.escapeForJavaScript(project, false, false);
+        build = WebUtil.escapeForJavaScript(build, false, false);
+        statusText = "<" + WebUtil.escapeUrlForQuotes(getServerUrl()) + "/viewLog.html?buildId=" + bt.getBuildId() + "&buildTypeId=" + btId + "|" + statusText + ">";
         String payloadText = project + " #" + build + " " + statusText;
         String attachmentProject = "{\"title\":\"Project\",\"value\":\"" + project + "\",\"short\": false}";
         String attachmentBuild = "{\"title\":\"Build\",\"value\":\"" + build + "\",\"short\": true}";
         String attachmentStatus = "{\"title\":\"Status\",\"value\":\"" + statusText + "\",\"short\": false}";
 
-        String formattedPayload = "payload={" +
+        String formattedPayload = "{" +
             "\"text\":\"" + payloadText + "\"," +
             "\"attachments\": [{" +
                 "\"fallback\":\"" + payloadText + "\"," +
@@ -119,5 +123,13 @@ public class SlackWrapper
     public String getChannel()
     {
         return this.channel;
+    }
+
+    public String getServerUrl() {
+        return serverUrl;
+    }
+
+    public void setServerUrl(String serverUrl) {
+        this.serverUrl = serverUrl;
     }
 }

--- a/teamcity-slack-integration-server/src/main/java/com/enlivenhq/slack/SlackWrapper.java
+++ b/teamcity-slack-integration-server/src/main/java/com/enlivenhq/slack/SlackWrapper.java
@@ -63,9 +63,13 @@ public class SlackWrapper
             inputStream = httpsURLConnection.getInputStream();
         }
         catch (IOException e) {
-            responseBody = e.getMessage() + ": ";
+            responseBody = e.getMessage();
             inputStream = httpsURLConnection.getErrorStream();
-            throw new IOException(getResponseBody(inputStream, responseBody));
+            if (inputStream != null) {
+                responseBody += ": ";
+                responseBody = getResponseBody(inputStream, responseBody);
+            }
+            throw new IOException(responseBody);
         }
 
         return getResponseBody(inputStream, responseBody);

--- a/teamcity-slack-integration-server/src/main/java/com/enlivenhq/slack/SlackWrapper.java
+++ b/teamcity-slack-integration-server/src/main/java/com/enlivenhq/slack/SlackWrapper.java
@@ -1,5 +1,7 @@
 package com.enlivenhq.slack;
 
+import jetbrains.buildServer.web.util.WebUtil;
+
 import javax.net.ssl.HttpsURLConnection;
 import java.io.*;
 import java.net.URL;
@@ -14,6 +16,9 @@ public class SlackWrapper
 
     public String send(String project, String build, String statusText, String statusColor) throws IOException
     {
+        project = WebUtil.encode(project);
+        build = WebUtil.encode(build);
+        statusText = WebUtil.encode(statusText);
         String payloadText = project + " #" + build + " " + statusText;
         String attachmentProject = "{\"title\":\"Project\",\"value\":\"" + project + "\",\"short\": false}";
         String attachmentBuild = "{\"title\":\"Build\",\"value\":\"" + build + "\",\"short\": true}";

--- a/teamcity-slack-integration-server/src/main/java/com/enlivenhq/teamcity/SlackNotificator.java
+++ b/teamcity-slack-integration-server/src/main/java/com/enlivenhq/teamcity/SlackNotificator.java
@@ -55,7 +55,7 @@ public class SlackNotificator implements Notificator {
     }
 
     public void notifyBuildFailed(@NotNull SRunningBuild sRunningBuild, @NotNull Set<SUser> users) {
-         sendNotification(sRunningBuild.getFullName(), sRunningBuild.getBuildNumber(), "failed", "danger", users, sRunningBuild);
+         sendNotification(sRunningBuild.getFullName(), sRunningBuild.getBuildNumber(), "failed: " + sRunningBuild.getStatusDescriptor().getText(), "danger", users, sRunningBuild);
     }
 
     public void notifyBuildFailedToStart(@NotNull SRunningBuild sRunningBuild, @NotNull Set<SUser> users) {

--- a/teamcity-slack-integration-server/src/main/java/com/enlivenhq/teamcity/SlackNotificator.java
+++ b/teamcity-slack-integration-server/src/main/java/com/enlivenhq/teamcity/SlackNotificator.java
@@ -37,8 +37,11 @@ public class SlackNotificator implements Notificator {
     private static final PropertyKey slackUsername = new NotificatorPropertyKey(type, slackUsernameKey);
     private static final PropertyKey slackUrl = new NotificatorPropertyKey(type, slackUrlKey);
 
-    public SlackNotificator(NotificatorRegistry notificatorRegistry) {
+    private SBuildServer myServer;
+
+    public SlackNotificator(NotificatorRegistry notificatorRegistry, SBuildServer server) {
         registerNotificatorAndUserProperties(notificatorRegistry);
+        myServer = server;
     }
 
     @NotNull
@@ -52,31 +55,31 @@ public class SlackNotificator implements Notificator {
     }
 
     public void notifyBuildFailed(@NotNull SRunningBuild sRunningBuild, @NotNull Set<SUser> users) {
-         sendNotification(sRunningBuild.getFullName(), sRunningBuild.getBuildNumber(), "failed", "danger", users);
+         sendNotification(sRunningBuild.getFullName(), sRunningBuild.getBuildNumber(), "failed", "danger", users, sRunningBuild);
     }
 
     public void notifyBuildFailedToStart(@NotNull SRunningBuild sRunningBuild, @NotNull Set<SUser> users) {
-        sendNotification(sRunningBuild.getFullName(), sRunningBuild.getBuildNumber(), "failed to start", "danger", users);
+        sendNotification(sRunningBuild.getFullName(), sRunningBuild.getBuildNumber(), "failed to start", "danger", users, sRunningBuild);
     }
 
     public void notifyBuildSuccessful(@NotNull SRunningBuild sRunningBuild, @NotNull Set<SUser> users) {
-        sendNotification(sRunningBuild.getFullName(), sRunningBuild.getBuildNumber(), "built successfully", "good", users);
+        sendNotification(sRunningBuild.getFullName(), sRunningBuild.getBuildNumber(), "built successfully", "good", users, sRunningBuild);
     }
 
     public void notifyLabelingFailed(@NotNull Build build, @NotNull VcsRoot vcsRoot, @NotNull Throwable throwable, @NotNull Set<SUser> sUsers) {
-        sendNotification(build.getFullName(), build.getBuildNumber(), "labeling failed", "danger", sUsers);
+        sendNotification(build.getFullName(), build.getBuildNumber(), "labeling failed", "danger", sUsers, build);
     }
 
     public void notifyBuildFailing(@NotNull SRunningBuild sRunningBuild, @NotNull Set<SUser> sUsers) {
-        sendNotification(sRunningBuild.getFullName(), sRunningBuild.getBuildNumber(), "failing", "danger", sUsers);
+        sendNotification(sRunningBuild.getFullName(), sRunningBuild.getBuildNumber(), "failing", "danger", sUsers, sRunningBuild);
     }
 
     public void notifyBuildProbablyHanging(@NotNull SRunningBuild sRunningBuild, @NotNull Set<SUser> sUsers) {
-        sendNotification(sRunningBuild.getFullName(), sRunningBuild.getBuildNumber(), "probably hanging", "warning", sUsers);
+        sendNotification(sRunningBuild.getFullName(), sRunningBuild.getBuildNumber(), "probably hanging", "warning", sUsers, sRunningBuild);
     }
 
     public void notifyBuildStarted(@NotNull SRunningBuild sRunningBuild, @NotNull Set<SUser> sUsers) {
-        sendNotification(sRunningBuild.getFullName(), sRunningBuild.getBuildNumber(), "started", "warning", sUsers);
+        sendNotification(sRunningBuild.getFullName(), sRunningBuild.getBuildNumber(), "started", "warning", sUsers, sRunningBuild);
     }
 
     public void notifyResponsibleChanged(@NotNull SBuildType sBuildType, @NotNull Set<SUser> sUsers) {
@@ -142,11 +145,11 @@ public class SlackNotificator implements Notificator {
         return userPropertyInfos;
     }
 
-    private void sendNotification(String project, String build, String statusText, String statusColor, Set<SUser> users) {
+    private void sendNotification(String project, String build, String statusText, String statusColor, Set<SUser> users, Build bt) {
         for (SUser user : users) {
             SlackWrapper slackWrapper = getSlackWrapperWithUser(user);
             try {
-                slackWrapper.send(project, build, statusText, statusColor);
+                slackWrapper.send(project, build, statusText, statusColor, bt);
             }
             catch (IOException e) {
                 log.error(e.getMessage());
@@ -179,6 +182,7 @@ public class SlackNotificator implements Notificator {
         slackWrapper.setChannel(channel);
         slackWrapper.setUsername(username);
         slackWrapper.setSlackUrl(url);
+        slackWrapper.setServerUrl(myServer.getRootUrl());
 
         return slackWrapper;
     }


### PR DESCRIPTION
* `urlencode` payload field values
* catch and log rare slack 503 responses with empty body
* insert link to the build into notification
* add to notification status text of the failed build