### PR TITLE
Use status badge from teamcity.jetbrains.com build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # teamcity-slack
+[![Build Status](https://teamcity.jetbrains.com/app/rest/builds/buildType:(id:TeamCityThirdPartyPlugins_TeamcitySlackNotifications_Build)/statusIcon.svg)](https://teamcity.jetbrains.com/viewType.html?buildTypeId=TeamCityThirdPartyPlugins_TeamcitySlackNotifications_Build)
+
 A configurable TeamCity plugin that notifies your [Slack](https://slack.com) channel.
 Because it is a [TeamCity Custom Notifier](http://confluence.jetbrains.com/display/TCD8/Custom+Notifier) plugin, it extends the existing user interface and allows for easy configuration directly within your TeamCity server. Once installed, you can configure the plugin for multiple TeamCity projects and multiple build conditions (i.e. Build failures, successes, hangs, etc.)
 

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -10,6 +10,7 @@
   <packaging>pom</packaging>
   <properties>
       <maven.build.timestamp.format>yyyyddMMHHmmss</maven.build.timestamp.format>
+      <plugin-version>snapshot-${maven.build.timestamp}</plugin-version>
   </properties>
   <dependencies>
       <dependency>
@@ -38,7 +39,7 @@
                 <replacements>
                     <replacement>
                         <token>@Version@</token>
-                        <value>snapshot-${maven.build.timestamp}</value>
+                        <value>${plugin-version}</value>
                     </replacement>
                 </replacements>                        
             </configuration>


### PR DESCRIPTION
The [build configuration](https://teamcity.jetbrains.com/project.html?projectId=TeamCityThirdPartyPlugins_TeamcitySlackNotifications) at teamcity.jetbrains.com for the plugin have been there for a while, I've configured it to produce somewhat better version numbers recently;  plugin zip file is available as build artefact, so it could be removed from the repository now. 