### PR TITLE
Bug fixes for posting multi-bytes message.

### DIFF
--- a/teamcity-slack-integration-server/src/main/java/com/enlivenhq/slack/SlackWrapper.java
+++ b/teamcity-slack-integration-server/src/main/java/com/enlivenhq/slack/SlackWrapper.java
@@ -53,7 +53,9 @@ public class SlackWrapper
             httpsURLConnection.getOutputStream()
         );
 
-        dataOutputStream.writeBytes(formattedPayload);
+        //dataOutputStream.writeBytes(formattedPayload);
+        byte[] array = formattedPayload.getBytes("UTF-8");
+        dataOutputStream.write(array, 0, array.length);
         dataOutputStream.flush();
         dataOutputStream.close();
 


### PR DESCRIPTION
Fixed a bug that was caused when the project name with multi-byte letters were posted to Slack.